### PR TITLE
Skip matching namespace if not found

### DIFF
--- a/tests/Fixtures/MissingNamespaceClass.php
+++ b/tests/Fixtures/MissingNamespaceClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class MissingNamespaceClass
+{
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #10

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Thorwing an error if namespace is not found in a file
```

<!--
     If this is a work in progress, uncomment this section.
     You can add as many tasks as you want.
     If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

There is no check if namespace line is not found and then if we try to use preg_match it throws an exception.