### PR TITLE
Fix path of scanning files for non flex application

### DIFF
--- a/src/DependencyInjection/SonataAnnotationExtension.php
+++ b/src/DependencyInjection/SonataAnnotationExtension.php
@@ -21,7 +21,7 @@ final class SonataAnnotationExtension extends Extension
 
         $container->setParameter(
             'sonata_annotation.directory',
-            $config['directory'] ?? $container->getParameter('kernel.root_dir')
+            $config['directory'] ?? $container->getParameter('kernel.project_dir') . '/src/'
         );
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/tests/DependencyInjection/SonataAnnotationExtensionTest.php
+++ b/tests/DependencyInjection/SonataAnnotationExtensionTest.php
@@ -16,7 +16,7 @@ final class SonataAnnotationExtensionTest extends AbstractExtensionTestCase
 {
     public function testLoadsFormServiceDefinition(): void
     {
-        $this->container->setParameter('kernel.root_dir', $param = 'test');
+        $this->container->setParameter('kernel.project_dir', $param = 'test');
 
         $this->load();
 
@@ -31,7 +31,7 @@ final class SonataAnnotationExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasParameter(
             'sonata_annotation.directory',
-            $param
+            $param . '/src/'
         );
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Not working on non flex applications
```

<!--
     If this is a work in progress, uncomment this section.
     You can add as many tasks as you want.
     If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

If the application was not using flex the kernel dir is `app` instead of `src` and auto register did not work because of this, project_dir gives us the root and this works now for both.