### PR TITLE
Allow symfony 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "php": "^7.1",
     "doctrine/annotations": "^1.6",
     "sonata-project/admin-bundle": "^3.35",
-    "symfony/config": "^3.4 || ^4.0",
-    "symfony/dependency-injection": "^3.4 || ^4.0",
-    "symfony/finder": "^3.4 || ^4.0",
-    "symfony/http-kernel": "^3.4 || ^4.0"
+    "symfony/config": "^3.4 || ^4.0 || ^4.1",
+    "symfony/dependency-injection": "^3.4 || ^4.0 || ^4.1",
+    "symfony/finder": "^3.4 || ^4.0 || ^4.1",
+    "symfony/http-kernel": "^3.4 || ^4.0 || ^4.1"
   },
   "conflict": {
     "sonata-project/admin-bundle": "<3.35"


### PR DESCRIPTION
No idea why I thought `^4.0` wouldn't work with 4.1 ....