### PR TITLE
If class doesn't exist exit

### DIFF
--- a/src/DependencyInjection/Compiler/AutoRegisterCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AutoRegisterCompilerPass.php
@@ -33,6 +33,10 @@ final class AutoRegisterCompilerPass implements CompilerPassInterface
                 continue;
             }
 
+            if (!\class_exists($className)) {
+                continue;
+            }
+
             if (!($annotation = $this->getClassAnnotation($reflection = new \ReflectionClass($className)))) {
                 continue;
             }


### PR DESCRIPTION
closes #23 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- An issue when compiler pass is trying to create a reflection of a class that doesn't exist
```