### PR TITLE
CRLF line separators used in entities

### DIFF
--- a/src/DependencyInjection/Compiler/AutoRegisterCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AutoRegisterCompilerPass.php
@@ -80,7 +80,7 @@ final class AutoRegisterCompilerPass implements CompilerPassInterface
             return null;
         }
 
-        preg_match('/namespace (.*);$/', reset($namespaceLine), $match);
+        preg_match('/namespace (.*);$/', trim(reset($namespaceLine)), $match);
 
         return array_pop($match);
     }


### PR DESCRIPTION
Closes #29 

## Changelog

```markdown
### Changed
- fixed an issue when CRLF line separators were used in entities
```