### PR TITLE
Add position to form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,10 @@ class Post
 
 You can specify action option that would allow you to have different fields or
 have different configuration for the same field for create and edit action.
-If not set, field will be used for create and edit.
+If not set, field will be used for create and edit. Besides that, you are able
+to set the position of the field. Position 1 would be the first field to 
+render and higher numbers after. If field doesn't have position, it will be 
+rendered after all fields with position.
 
 ```php
 <?php
@@ -265,7 +268,8 @@ class Category
      *      action="create",
      *      type="",
      *      options={},
-     *      fieldDescriptionOptions={}
+     *      fieldDescriptionOptions={},
+     *      position=1 
      * )
      *
      * @ORM\Column(name="name", type="string", length=255)
@@ -276,7 +280,8 @@ class Category
      * @Sonata\FormField(
      *      type="",
      *      options={},
-     *      fieldDescriptionOptions={}
+     *      fieldDescriptionOptions={},
+     *      position=2
      * )
      *
      * @ORM\Column(name="description", type="string", length=255)

--- a/src/Annotation/FormField.php
+++ b/src/Annotation/FormField.php
@@ -25,6 +25,11 @@ final class FormField extends AbstractField
      */
     public $options = [];
 
+    /**
+     * @var integer
+     */
+    public $position;
+
     public function getSettings(): array
     {
         return [
@@ -32,5 +37,15 @@ final class FormField extends AbstractField
             $this->options,
             $this->fieldDescriptionOptions
         ];
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function hasPosition(): bool
+    {
+        return $this->position !== null;
     }
 }

--- a/src/Reader/FormReader.php
+++ b/src/Reader/FormReader.php
@@ -21,14 +21,46 @@ final class FormReader
 
     private function configureFields(\ReflectionClass $class, FormMapper $formMapper, string $action): void
     {
+        $propertiesWithPosition = [];
+        $propertiesWithoutPosition = [];
+
         foreach ($class->getProperties() as $property) {
             foreach ($this->getPropertyAnnotations($property) as $annotation) {
                 if (!$annotation instanceof FormField || $annotation->action === $action) {
                     continue;
                 }
 
-                $formMapper->add($property->getName(), ...$annotation->getSettings());
+                if (!$annotation->hasPosition()) {
+                    $propertiesWithoutPosition[] = [
+                        'name' => $property->getName(),
+                        'settings' => $annotation->getSettings(),
+                    ];
+
+                    continue;
+                }
+
+                if (\array_key_exists($annotation->position, $propertiesWithPosition)) {
+                    throw new \InvalidArgumentException(sprintf(
+                        'Position "%s" is already in use by "%s", try setting a different position for "%s".',
+                        $annotation->position,
+                        $propertiesWithPosition[$annotation->position]['name'],
+                        $property->getName()
+                    ));
+                }
+
+                $propertiesWithPosition[$annotation->position] = [
+                    'name' => $property->getName(),
+                    'settings' => $annotation->getSettings(),
+                ];
             }
+        }
+
+        \ksort($propertiesWithPosition);
+
+        $properties = \array_merge($propertiesWithPosition, $propertiesWithoutPosition);
+
+        foreach ($properties as $property) {
+            $formMapper->add($property['name'], ...$property['settings']);
         }
     }
 

--- a/tests/Fixtures/AnnotationClass.php
+++ b/tests/Fixtures/AnnotationClass.php
@@ -32,7 +32,7 @@ final class AnnotationClass
      * @Sonata\ExportField()
      * @Sonata\ShowField()
      * @Sonata\DatagridField()
-     * @Sonata\FormField(action="create")
+     * @Sonata\FormField(action="create", position=2)
      * @Sonata\ListField(identifier=true)
      */
     private $field;
@@ -42,7 +42,7 @@ final class AnnotationClass
      * @Sonata\ShowAssociationField(field="name")
      * @Sonata\DatagridAssociationField(field="name")
      * @Sonata\ListAssociationField(field="name")
-     * @Sonata\FormField()
+     * @Sonata\FormField(position=1)
      */
     private $parent;
 
@@ -52,6 +52,11 @@ final class AnnotationClass
      * @Sonata\ListField()
      */
     private $additionalField;
+
+    /**
+     * @Sonata\FormField()
+     */
+    private $additionalField2;
 
     /**
      * @Sonata\ExportField()

--- a/tests/Fixtures/AnnotationExceptionClass.php
+++ b/tests/Fixtures/AnnotationExceptionClass.php
@@ -27,6 +27,12 @@ final class AnnotationExceptionClass
      * @Sonata\ShowAssociationField()
      * @Sonata\ListAssociationField()
      * @Sonata\DatagridAssociationField()
+     * @Sonata\FormField(position=1)
      */
     private $field;
+
+    /**
+     * @Sonata\FormField(position=1)
+     */
+    private $field2;
 }

--- a/tests/Reader/FormReaderTest.php
+++ b/tests/Reader/FormReaderTest.php
@@ -7,6 +7,7 @@ namespace KunicMarko\SonataAnnotationBundle\Tests\Reader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use KunicMarko\SonataAnnotationBundle\Reader\FormReader;
 use KunicMarko\SonataAnnotationBundle\Tests\Fixtures\AnnotationClass;
+use KunicMarko\SonataAnnotationBundle\Tests\Fixtures\AnnotationExceptionClass;
 use KunicMarko\SonataAnnotationBundle\Tests\Fixtures\EmptyClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -42,6 +43,7 @@ final class FormReaderTest extends TestCase
     {
         $this->formMapper->add('field', Argument::cetera())->shouldBeCalled();
         $this->formMapper->add('parent', Argument::cetera())->shouldBeCalled();
+        $this->formMapper->add('additionalField2', Argument::cetera())->shouldBeCalled();
 
         $this->formReader->configureCreateFields(
             new \ReflectionClass(AnnotationClass::class),
@@ -53,9 +55,41 @@ final class FormReaderTest extends TestCase
     {
         $this->formMapper->add('additionalField', Argument::cetera())->shouldBeCalled();
         $this->formMapper->add('parent', Argument::cetera())->shouldBeCalled();
+        $this->formMapper->add('additionalField2', Argument::cetera())->shouldBeCalled();
 
         $this->formReader->configureEditFields(
             new \ReflectionClass(AnnotationClass::class),
+            $this->formMapper->reveal()
+        );
+    }
+
+    public function testConfigureCreateFieldsAnnotationPresentPosition(): void
+    {
+        $mock = $this->createMock(FormMapper::class);
+
+        $properties = ['parent', 'field', 'additionalField2'];
+        $mock->expects($this->exactly(3))
+            ->method('add')
+            ->with($this->callback(static function(string $field) use (&$properties): bool {
+                $property = array_shift($properties);
+                return $field === $property;
+            }));
+
+        $this->formReader->configureCreateFields(
+            new \ReflectionClass(AnnotationClass::class),
+            $mock
+        );
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testPositionShouldBeUnique(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Position "1" is already in use by "field", try setting a different position for "field2".');
+        $this->formReader->configureCreateFields(
+            new \ReflectionClass(AnnotationExceptionClass::class),
             $this->formMapper->reveal()
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch because this is a new feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added position to form fields that allows specifying in which order they will be added
```

<!--
     If this is a work in progress, uncomment this section.
     You can add as many tasks as you want.
     If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->