### PR TITLE
Changed fieldOptions type to array

### DIFF
--- a/src/Annotation/DatagridField.php
+++ b/src/Annotation/DatagridField.php
@@ -23,9 +23,9 @@ class DatagridField extends AbstractField
     public $fieldType;
 
     /**
-     * @var string
+     * @var array
      */
-    public $fieldOptions;
+    public $fieldOptions = [];
 
     public function getSettings(): array
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch because it's the last one.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #33 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- wrong field type causing DatagridField annotation to fail
```